### PR TITLE
Forceful tentacle destruction

### DIFF
--- a/AzureWebFarm.OctopusDeploy.Tests/AzureWebFarm.OctopusDeploy.Tests.csproj
+++ b/AzureWebFarm.OctopusDeploy.Tests/AzureWebFarm.OctopusDeploy.Tests.csproj
@@ -60,8 +60,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NSubstitute.1.7.2.0\lib\NET45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Client, Version=3.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Client.3.2.0\lib\net40\Octopus.Client.dll</HintPath>
+    <Reference Include="Octopus.Client, Version=3.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Client.3.2.1\lib\net40\Octopus.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly">

--- a/AzureWebFarm.OctopusDeploy.Tests/packages.config
+++ b/AzureWebFarm.OctopusDeploy.Tests/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />
-  <package id="Octopus.Client" version="3.2.0" targetFramework="net45" />
+  <package id="Octopus.Client" version="3.2.1" targetFramework="net45" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />

--- a/AzureWebFarm.OctopusDeploy/AzureWebFarm.OctopusDeploy.csproj
+++ b/AzureWebFarm.OctopusDeploy/AzureWebFarm.OctopusDeploy.csproj
@@ -59,8 +59,8 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Client, Version=3.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Client.3.2.0\lib\net40\Octopus.Client.dll</HintPath>
+    <Reference Include="Octopus.Client, Version=3.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Client.3.2.1\lib\net40\Octopus.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=1.2.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
+++ b/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
@@ -78,6 +78,20 @@ namespace AzureWebFarm.OctopusDeploy.Infrastructure
 
         public void DeleteMachine()
         {
+            try
+            {
+                DeleteMachineInternal();
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Initial attempt to remove machine from Octopus repository failed. Will retry 1 time.");
+                DeleteMachineInternal();
+                Log.Information("Successfully deleted machine from Octopus repository");
+            }
+        }
+
+        private void DeleteMachineInternal()
+        {
             var machine = _repository.Machines.FindByName(_machineName);
             _repository.Machines.Delete(machine);
         }

--- a/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
+++ b/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
@@ -78,25 +78,6 @@ namespace AzureWebFarm.OctopusDeploy.Infrastructure
 
         public void DeleteMachine()
         {
-            var remainingAttempts = 5;
-            while (remainingAttempts > 0)
-            {
-                try
-                {
-                    DeleteMachineInternal();
-                    return;
-                }
-                catch (Exception e)
-                {
-                    remainingAttempts--;
-                    Log.Error(e, "Initial attempt to remove machine from Octopus repository failed. Will retry {attempts} time(s).", remainingAttempts);
-                    Thread.Sleep(TimeSpan.FromSeconds(3));
-                }
-            }
-        }
-
-        private void DeleteMachineInternal()
-        {
             var machine = _repository.Machines.FindByName(_machineName);
             _repository.Machines.Delete(machine);
         }

--- a/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
+++ b/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
@@ -53,7 +53,8 @@ namespace AzureWebFarm.OctopusDeploy.Infrastructure
             {
                 try
                 {
-                    Log.Information("Detected existing tentacle.config - possible abrupt restart. Deleting tentacle.config.");
+                    Log.Information(
+                        "Detected existing tentacle.config - possible abrupt restart. Deleting tentacle.config.");
                     File.Delete(Path.Combine(_tentacleInstallPath, "Tentacle.config"));
                     Log.Information("Successfully removed tentacle.config from role.");
                 }
@@ -61,10 +62,13 @@ namespace AzureWebFarm.OctopusDeploy.Infrastructure
                 {
                     Log.Error(e, "Failed to remove certificate from Octopus server. Manual intevention required.");
                 }
+            }
 
+            if (_repository.Machines.FindByName(_machineName) != null)
+            {
                 try
                 {
-                    Log.Information("Attempting to remove tentacle from Octopus server.");
+                    Log.Information("Detected existing machine using this name. Attempting to remove tentacle from Octopus server.");
                     DeleteMachine();
                     Log.Information("Successfully removed tentacle from Octopus server.");
                 }
@@ -72,7 +76,6 @@ namespace AzureWebFarm.OctopusDeploy.Infrastructure
                 {
                     Log.Error(e, "Failed to remove tentacle from Octopus server. Manual intevention required.");
                 }
-
             }
         }
 
@@ -100,7 +103,7 @@ namespace AzureWebFarm.OctopusDeploy.Infrastructure
                             Comments = "Automated startup deployment by " + _machineName,
                             EnvironmentId = currentRelease.EnvironmentId,
                             ReleaseId = currentRelease.ReleaseId,
-                            SpecificMachineIds = new ReferenceCollection(new[] {machineId})
+                            SpecificMachineIds = new ReferenceCollection(new[] { machineId })
                         }
                     ))
                     .Select(d => d.TaskId)

--- a/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
+++ b/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
@@ -78,15 +78,20 @@ namespace AzureWebFarm.OctopusDeploy.Infrastructure
 
         public void DeleteMachine()
         {
-            try
+            var remainingAttempts = 5;
+            while (remainingAttempts > 0)
             {
-                DeleteMachineInternal();
-            }
-            catch (Exception e)
-            {
-                Log.Error(e, "Initial attempt to remove machine from Octopus repository failed. Will retry 1 time.");
-                DeleteMachineInternal();
-                Log.Information("Successfully deleted machine from Octopus repository");
+                try
+                {
+                    DeleteMachineInternal();
+                    return;
+                }
+                catch (Exception e)
+                {
+                    remainingAttempts--;
+                    Log.Error(e, "Initial attempt to remove machine from Octopus repository failed. Will retry {attempts} time(s).", remainingAttempts);
+                    Thread.Sleep(TimeSpan.FromSeconds(3));
+                }
             }
         }
 

--- a/AzureWebFarm.OctopusDeploy/packages.config
+++ b/AzureWebFarm.OctopusDeploy/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Octopus.Client" version="3.2.0" targetFramework="net45" />
+  <package id="Octopus.Client" version="3.2.1" targetFramework="net45" />
   <package id="Serilog" version="1.2.25" targetFramework="net45" />
   <package id="Serilog.Sinks.AzureTableStorage" version="1.2.25" targetFramework="net45" />
   <package id="System.Spatial" version="5.2.0" targetFramework="net45" />

--- a/ExampleWebFarm/ExampleWebFarm.csproj
+++ b/ExampleWebFarm/ExampleWebFarm.csproj
@@ -69,8 +69,8 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Client, Version=3.2.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Client.3.2.0\lib\net40\Octopus.Client.dll</HintPath>
+    <Reference Include="Octopus.Client, Version=3.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Client.3.2.1\lib\net40\Octopus.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=1.2.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
@@ -105,7 +105,9 @@
   <ItemGroup>
     <Content Include="Default.aspx" />
     <Content Include="Global.asax" />
-    <Content Include="Web.config" />
+    <Content Include="Web.config">
+      <SubType>Designer</SubType>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="packages.config">

--- a/ExampleWebFarm/packages.config
+++ b/ExampleWebFarm/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Octopus.Client" version="3.2.0" targetFramework="net45" />
+  <package id="Octopus.Client" version="3.2.1" targetFramework="net45" />
   <package id="Serilog" version="1.2.25" targetFramework="net45" />
   <package id="Serilog.Sinks.AzureTableStorage" version="1.2.25" targetFramework="net45" />
   <package id="System.Spatial" version="5.2.0" targetFramework="net45" />


### PR DESCRIPTION
I've had a bunch of incidents where the role recycles but the tentacle failed to uninstall properly.

This patch 
 - attempts twice to remove the machine from the repository should the first attempt fail
 - looks for a failed uninstall on restart, and re-registers the tentacle with octopus.