### PR TITLE
Breaking change in Octopus Client 3.3.x

### DIFF
--- a/AzureWebFarm.OctopusDeploy.Tests/AzureWebFarm.OctopusDeploy.Tests.csproj
+++ b/AzureWebFarm.OctopusDeploy.Tests/AzureWebFarm.OctopusDeploy.Tests.csproj
@@ -60,8 +60,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NSubstitute.1.7.2.0\lib\NET45\NSubstitute.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Client, Version=3.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Client.3.2.1\lib\net40\Octopus.Client.dll</HintPath>
+    <Reference Include="Octopus.Client, Version=3.3.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Client.3.3.11\lib\net40\Octopus.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly">

--- a/AzureWebFarm.OctopusDeploy.Tests/packages.config
+++ b/AzureWebFarm.OctopusDeploy.Tests/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Web.Xdt" version="1.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NSubstitute" version="1.7.2.0" targetFramework="net45" />
-  <package id="Octopus.Client" version="3.2.1" targetFramework="net45" />
+  <package id="Octopus.Client" version="3.3.11" targetFramework="net45" />
   <package id="Shouldly" version="1.1.1.1" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />

--- a/AzureWebFarm.OctopusDeploy/AzureWebFarm.OctopusDeploy.csproj
+++ b/AzureWebFarm.OctopusDeploy/AzureWebFarm.OctopusDeploy.csproj
@@ -59,8 +59,8 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Client, Version=3.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Client.3.2.1\lib\net40\Octopus.Client.dll</HintPath>
+    <Reference Include="Octopus.Client, Version=3.3.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Client.3.3.11\lib\net40\Octopus.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=1.2.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
+++ b/AzureWebFarm.OctopusDeploy/Infrastructure/OctopusDeploy.cs
@@ -99,8 +99,8 @@ namespace AzureWebFarm.OctopusDeploy.Infrastructure
                                .Steps
                                .Any(s =>
                                {
-                                   string value;
-                                   return s.Properties.TryGetValue(targetRolePropertyName, out value) && value == _config.TentacleRole;
+                                   PropertyValueResource value;
+                                   return s.Properties.TryGetValue(targetRolePropertyName, out value) && value != null && value.Value == _config.TentacleRole;
                                }))
                     .Select(p => p.Id);
 

--- a/AzureWebFarm.OctopusDeploy/packages.config
+++ b/AzureWebFarm.OctopusDeploy/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Octopus.Client" version="3.2.1" targetFramework="net45" />
+  <package id="Octopus.Client" version="3.3.11" targetFramework="net45" />
   <package id="Serilog" version="1.2.25" targetFramework="net45" />
   <package id="Serilog.Sinks.AzureTableStorage" version="1.2.25" targetFramework="net45" />
   <package id="System.Spatial" version="5.2.0" targetFramework="net45" />

--- a/ExampleWebFarm/ExampleWebFarm.csproj
+++ b/ExampleWebFarm/ExampleWebFarm.csproj
@@ -70,8 +70,8 @@
       <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octopus.Client, Version=3.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Client.3.2.1\lib\net40\Octopus.Client.dll</HintPath>
+    <Reference Include="Octopus.Client, Version=3.3.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Client.3.3.11\lib\net40\Octopus.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=1.2.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/ExampleWebFarm/packages.config
+++ b/ExampleWebFarm/packages.config
@@ -5,7 +5,7 @@
   <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-  <package id="Octopus.Client" version="3.2.1" targetFramework="net45" />
+  <package id="Octopus.Client" version="3.3.11" targetFramework="net45" />
   <package id="Serilog" version="1.2.25" targetFramework="net45" />
   <package id="Serilog.Sinks.AzureTableStorage" version="1.2.25" targetFramework="net45" />
   <package id="System.Spatial" version="5.2.0" targetFramework="net45" />


### PR DESCRIPTION
Some new code to introspect deployments breaks against 3.3.x. Upgrading client, and fixing.
Sadly I think this will need to be another major version bump as this won't work against 3.2.x
